### PR TITLE
chore: disable release dry run

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,4 +45,4 @@ jobs:
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      run: npx semantic-release --dry-run
+      run: npx semantic-release


### PR DESCRIPTION
Closes #90 

Once this PR is merged `npm-swipl-wasm` will begin performing automated release based on semantic commits to the main branch.

[This dry run](https://github.com/SWI-Prolog/npm-swipl-wasm/actions/runs/4663640467/jobs/8256374548#step:7:1179) correctly indicates that v3.2.0 will be created when this PR is merged.
