### PR TITLE
fix: update to emsdk v3.1.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
       "commit": "dafe1a88bca7b834cc729c76141b6b5d6a628e73"
     },
     "emsdk": {
-      "version": "3.1.32"
+      "version": "3.1.37",
+      "commit": "b113f24842c6e97fe3e352084db09a6e278593ae"
     },
     "zlib": {
       "version": "1.2.13"


### PR DESCRIPTION
fix: update to emsdk v3.1.37

https://github.com/SWI-Prolog/swipl-devel/pull/1171 solves one of the issues; but we get a `_free` is not (run by running `npm run test:minimal`) on the no-bundle. Free appears to exist in all other environments.

The same error occurs trying to use the no-bundle file in swipl-wasm.

**Note** that this `_free` error does *not* occur with emsdk v3.1.36 and so we can update to that once the next version of swipl is released.