### PR TITLE
fix: upgrade to emscripten 3.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       "commit": "20b7ede92a13cd37430673bae1c0fcbc9cfcaf9d"
     },
     "emsdk": {
-      "version": "3.1.32"
+      "version": "3.1.34"
     },
     "zlib": {
       "version": "1.2.13"


### PR DESCRIPTION
#127 fails because of `allocateUTF8` being removed in 3.1.35 so lets set if we can at least upgrade to 3.1.34 which has fixes for the memory leak bugs