### PR TITLE
fix: migrate to universal fetch and use it as a direct dependency

### DIFF
--- a/dist/generateImage.ts
+++ b/dist/generateImage.ts
@@ -2,7 +2,7 @@
 
 import SWIPL from './swipl/swipl-bundle';
 import fs from 'fs';
-import { fetch } from 'cross-fetch';
+import { fetch } from '@inrupt/universal-fetch';
 
 function Uint8ToString(u8a: Uint8Array) {
   const CHUNK_SZ = 0x8000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@inrupt/universal-fetch": "^1.0.1"
+        "@inrupt/universal-fetch": "^1.0.1",
+        "@types/emscripten": "^1.39.6"
       },
       "bin": {
         "swipl-generate": "dist/bin/index.js"
@@ -17,7 +18,6 @@
       "devDependencies": {
         "@octokit/rest": "^19.0.7",
         "@qiwi/semantic-release-gh-pages-plugin": "^5.2.5",
-        "@types/emscripten": "^1.39.6",
         "@types/fs-extra": "^11.0.1",
         "@types/node": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
@@ -34,9 +34,6 @@
         "typescript": "^5.0.4",
         "webpack": "^5.82.0",
         "webpack-cli": "^5.1.1"
-      },
-      "peerDependencies": {
-        "@types/emscripten": "^1.39.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1284,8 +1281,8 @@
     },
     "node_modules/@types/emscripten": {
       "version": "1.39.6",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+      "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg=="
     },
     "node_modules/@types/eslint": {
       "version": "8.37.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "swipl-wasm",
       "version": "3.1.0",
       "license": "BSD-2-Clause",
+      "dependencies": {
+        "@inrupt/universal-fetch": "^1.0.1"
+      },
       "bin": {
         "swipl-generate": "dist/bin/index.js"
       },
@@ -19,7 +22,6 @@
         "@types/node": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
         "@typescript-eslint/parser": "^5.59.5",
-        "cross-fetch": "^3.1.5",
         "eslint": "^8.40.0",
         "fs-extra": "^11.1.1",
         "http-server": "^14.1.1",
@@ -253,6 +255,15 @@
       "version": "1.2.1",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@inrupt/universal-fetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
+      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
+      "dependencies": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.19.1"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -2178,6 +2189,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "dev": true,
@@ -2906,7 +2928,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4342,7 +4363,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5630,7 +5651,6 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -10120,7 +10140,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/schema-utils": {
@@ -10844,6 +10864,14 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "dev": true,
@@ -11242,7 +11270,6 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/traverse": {
@@ -11432,6 +11459,17 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/union": {
       "version": "0.5.0",
       "dev": true,
@@ -11545,7 +11583,6 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -11680,7 +11717,6 @@
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@octokit/rest": "^19.0.7",
     "@qiwi/semantic-release-gh-pages-plugin": "^5.2.5",
-    "@types/emscripten": "^1.39.6",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^20.1.1",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
@@ -74,9 +73,6 @@
     "bundle:webpack": "webpack --config webpack.config.js",
     "bundle:latest": "ts-node scripts/post-webpack"
   },
-  "peerDependencies": {
-    "@types/emscripten": "^1.39.6"
-  },
   "config": {
     "swipl": {
       "version": "9.1.9",
@@ -119,6 +115,7 @@
     ]
   },
   "dependencies": {
-    "@inrupt/universal-fetch": "^1.0.1"
+    "@inrupt/universal-fetch": "^1.0.1",
+    "@types/emscripten": "^1.39.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/node": "^20.1.1",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "@typescript-eslint/parser": "^5.59.5",
-    "cross-fetch": "^3.1.5",
     "eslint": "^8.40.0",
     "fs-extra": "^11.1.1",
     "http-server": "^14.1.1",
@@ -118,5 +117,8 @@
         }
       ]
     ]
+  },
+  "dependencies": {
+    "@inrupt/universal-fetch": "^1.0.1"
   }
 }

--- a/scripts/get-latest-gmp.ts
+++ b/scripts/get-latest-gmp.ts
@@ -1,5 +1,5 @@
 import { getPackage, isHigherVersion, savePackage } from './util';
-import { fetch } from 'cross-fetch';
+import { fetch } from '@inrupt/universal-fetch';
 
 async function main() {
   const downloads = await fetch('https://gmplib.org/download/gmp/');

--- a/scripts/get-latest-zlib.ts
+++ b/scripts/get-latest-zlib.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 import { getPackage, savePackage } from "./util";
-import { fetch } from 'cross-fetch';
+import { fetch } from '@inrupt/universal-fetch';
 
 (async () => {
   const res = (await fetch('https://api.github.com/repos/madler/zlib/releases/latest'));


### PR DESCRIPTION
Closes #165 and resolves https://github.com/eyereasoner/eye-js/issues/321