### PR TITLE
BREAKING CHANGE: attempt to get emsdk v4 working

### DIFF
--- a/dist/generateImage.ts
+++ b/dist/generateImage.ts
@@ -21,7 +21,7 @@ export async function generateImageBuffer(prolog: string | Buffer): Promise<Uint
     preRun: [(module: SWIPLModule) => { module.FS.writeFile('prolog.pl', prolog) }],
   });
 
-  // @ts-ignore
+  // @ts-expect-error
   Module.onRuntimeInitialized();
   Module.prolog.query("qsave_program('prolog.pvm')").once();
   return Module.FS.readFile('prolog.pvm')

--- a/dist/generateImage.ts
+++ b/dist/generateImage.ts
@@ -21,6 +21,8 @@ export async function generateImageBuffer(prolog: string | Buffer): Promise<Uint
     preRun: [(module: SWIPLModule) => { module.FS.writeFile('prolog.pl', prolog) }],
   });
 
+  // @ts-ignore
+  Module.onRuntimeInitialized();
   Module.prolog.query("qsave_program('prolog.pvm')").once();
   return Module.FS.readFile('prolog.pvm')
 }

--- a/dist/generateImage.ts
+++ b/dist/generateImage.ts
@@ -21,7 +21,8 @@ export async function generateImageBuffer(prolog: string | Buffer): Promise<Uint
     preRun: [(module: SWIPLModule) => { module.FS.writeFile('prolog.pl', prolog) }],
   });
 
-  // @ts-expect-error
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   Module.onRuntimeInitialized();
   Module.prolog.query("qsave_program('prolog.pvm')").once();
   return Module.FS.readFile('prolog.pvm')

--- a/examples/generation/dist/main.ts
+++ b/examples/generation/dist/main.ts
@@ -2,6 +2,8 @@ import SWIPL from './max';
 
 async function main() {
   const Module = await SWIPL();
+  // @ts-ignore
+  Module.onRuntimeInitialized();
   const res = Module.prolog.query('myMax(A, B, C).', { A: 1, B: 2 });
   if ((res.once() as { C: number }).C !== 2) {
     throw new Error('Failed to find max')

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
       "name": "V9.3.19"
     },
     "emsdk": {
-      "version": "3.1.74",
-      "commit": "3d6d8ee910466516a53e665b86458faa81dae9ba",
-      "name": "3.1.74"
+      "version": "4.0.2",
+      "commit": "539e4044b78c3f9ef9c0539b673e48a59ed54803",
+      "name": "4.0.2"
     },
     "zlib": {
       "version": "1.3.1"

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
       "name": "V9.3.20"
     },
     "emsdk": {
-      "version": "4.0.2",
-      "commit": "539e4044b78c3f9ef9c0539b673e48a59ed54803",
-      "name": "4.0.2"
+      "version": "4.0.3",
+      "commit": "127ce42cd5f0aabe2d9b5d636041ccef7c66d165",
+      "name": "4.0.3"
     },
     "zlib": {
       "version": "1.3.1"

--- a/tests/node.js
+++ b/tests/node.js
@@ -57,6 +57,7 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
     for (const package of packages) {
       it(`[${name}] ` + "should support the package " + package, async () => {
         const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+        console.log(swipl)
         const importResult = swipl.prolog.query(`use_module(library(${package})).`).once().success;
         assert.strictEqual(importResult, true);
         assert.deepEqual(logMessages, []);

--- a/tests/node.js
+++ b/tests/node.js
@@ -57,7 +57,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
     for (const package of packages) {
       it(`[${name}] ` + "should support the package " + package, async () => {
         const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
-        console.log(swipl)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        swipl.onRuntimeInitialized();
         const importResult = swipl.prolog.query(`use_module(library(${package})).`).once().success;
         assert.strictEqual(importResult, true);
         assert.deepEqual(logMessages, []);
@@ -70,6 +72,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
       assert.strictEqual(typeof SWIPL, "function");
   
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
   
       assert.strictEqual(typeof swipl.FS, "object");
       assert.strictEqual(typeof swipl.FS.writeFile, "function");
@@ -84,6 +89,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should run simple query", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       assert.strictEqual(
         swipl.prolog.query("member(X, [a, b, c]).").once().X,
         "a"
@@ -95,6 +103,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should run query with arguments", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       assert.strictEqual(
         swipl.prolog.query("member(X, Y).", { Y: ["a", "b", "c"] }).once().X,
         "a"
@@ -106,6 +117,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should run failing query", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const response = swipl.prolog.query("true").once();
       assert.strictEqual(response.$tag, "bindings");
       assert.deepEqual(logMessages, []);
@@ -115,6 +129,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should run throwing query", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const response = swipl.prolog.query("throw(error(test, _))").once();
       assert.strictEqual(response.error, true);
 
@@ -126,6 +143,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
     it(`[${name}] ` + "should eval javascript", async () => {
       global.wasRun = false;
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       await swipl.prolog.forEach("js_run_script(Script)", {
         Script: `global.wasRun = true;`,
       });
@@ -137,6 +157,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should query SWI-Prolog version", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const version = swipl.prolog
         .query("current_prolog_flag(version, Version)")
         .once().Version;
@@ -148,6 +171,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
 
     it(`[${name}] ` + "should query SWI-Prolog Input", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const res = swipl.prolog
         .call("await('inputV', Input)", { async: true })
       assert.strictEqual("inputV", res.yield);
@@ -160,6 +186,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
   
     it(`[${name}] ` + "should have predictable term conversion", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const atom = swipl.prolog.query("X = atom").once().X;
       assert.strictEqual(atom, "atom");
       assert.deepEqual(logMessages, []);
@@ -169,6 +198,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
 
     it(`[${name}] ` + "should handle big ints", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       const atom = swipl.prolog.query("X is 555555555555555555555555555555555555555555555555555555").once().X;
       assert.strictEqual(atom, 555555555555555555555555555555555555555555555555555555n);
       assert.deepEqual(logMessages, []);
@@ -178,6 +210,9 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
 
     it(`[${name}] ` + "should do regex operations enabled by pcre2", async () => {
       const swipl = await SWIPL({ arguments: ["-q"], ...addedParams });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      swipl.onRuntimeInitialized();
       assert.strictEqual(swipl.prolog.query("use_module(library(pcre)).").once().success, true);
       assert.strictEqual(swipl.prolog.query("re_match(\"^needle\"/i, \"Needle in a haystack\").").once().success, true);
       assert.strictEqual(swipl.prolog.query("re_match(\"^[0-9]{4}$\"/i, \"2023\").").once().success, true);


### PR DESCRIPTION
DO NOT MERGE

Shows that the reason CI was failing is because `onRuntimeInitialized` is not being called; but this should be fixed upstream.

See https://github.com/SWI-Prolog/swipl-devel/issues/1343