### PR TITLE
feat: add swipl-web-no-data build variant (external wasm, no data)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,10 @@ jobs:
       with:
         node-version: "24.15"
     - run: npm ci
-    - run: echo "CACHE_KEY=$(cat ./build-config.json | jq '[.[]] | map(.version, .commit) | @tsv')" >> $GITHUB_ENV
+    # The cache key covers everything that determines the WASM artifacts:
+    # the pinned dependency versions AND the Docker build definition, so
+    # that changes to docker/ invalidate previously cached artifacts.
+    - run: echo "CACHE_KEY=$(cat ./build-config.json | jq '[.[]] | map(.version, .commit) | @tsv')-$(cat docker/* | sha256sum | cut -c1-16)" >> $GITHUB_ENV
 
     - name: Restore cached build
       id: cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 dist/swipl/*.js
 dist/swipl/swipl-web.data
 dist/swipl/swipl-web.wasm
+dist/swipl/swipl-web-no-data.wasm
+examples/no-data-image.pvm
 examples/webpack/node_modules
 examples/webpack/public/*.data
 examples/webpack/public/*.wasm
@@ -12,6 +14,8 @@ dist/loadImage.js
 dist/loadImage.d.ts
 dist/loadImageDefault.js
 dist/loadImageDefault.d.ts
+dist/loadImageWeb.js
+dist/loadImageWeb.d.ts
 dist/generateImage.js
 dist/generateImage.d.ts
 dist/strToBuffer.js

--- a/README.md
+++ b/README.md
@@ -98,6 +98,45 @@ the `.js` file instead.
 </script>
 ```
 
+## Using the No-Data Web Build
+
+The build matrix also contains `swipl-web-no-data.js`: like `swipl-web.js`
+the WebAssembly stays in an external `swipl-web-no-data.wasm` file (so
+browsers can compile it with `WebAssembly.instantiateStreaming` and cache it
+independently of your application code), but like `swipl-bundle-no-data.js`
+there is no `.data` file at all.
+
+Because the standard Prolog library is not shipped, this build must be
+booted from a saved state (see "Generating an Image" below):
+
+```html
+<div id="solution"></div>
+<script src="/dist/swipl/swipl-web-no-data.js"></script>
+<script>
+  (async () => {
+    const response = await fetch("/path/to/your-image.pvm");
+    const image = new Uint8Array(await response.arrayBuffer());
+    const swipl = await SWIPL({
+      arguments: ["-q", "-x", "image.pvm"],
+      preRun: [(module) => module.FS.writeFile("image.pvm", image)],
+      locateFile: (path) => `/dist/swipl/${path}`,
+    });
+    const solutionElement = document.getElementById("solution");
+    solutionElement.textContent = swipl.prolog.query("hello(X).").once().X;
+  })();
+</script>
+```
+
+This is the smallest way to deliver SWI-Prolog over the wire: roughly the
+brotli-compressed size of the `.wasm` plus a small JS glue, instead of
+additionally downloading the `.data` file (`swipl-web`) or downloading and
+parsing a single large JavaScript file with the WebAssembly embedded in
+base64 (`swipl-bundle-no-data`).
+
+You can run this example by executing `npm run test:serve-http` and
+visiting <http://localhost:8080/examples/browser-no-data.html> (the test
+suite generates the saved state used by that page).
+
 ## Generating an Image
 
 Often you will want to bundle a pre-built image of your Prolog file. The easiest way to do this is using the `swipl-generate` command to generate the image. For example, in `./examples/generation`, the script `npx swipl-generate ./max.pl ./dist/max.ts` will generate a file `./dist/max.ts` which contains the image of `./max.pl`. This file can then be imported into your project and used as follows:

--- a/dist/loadImageWeb.ts
+++ b/dist/loadImageWeb.ts
@@ -1,0 +1,6 @@
+import SWIPL from './swipl/swipl-web-no-data';
+import { loadImage } from './loadImage'
+
+export default function(image: string | Buffer | Uint8Array) {
+  return loadImage(image, SWIPL);
+}

--- a/dist/swipl/swipl-web-no-data.d.ts
+++ b/dist/swipl/swipl-web-no-data.d.ts
@@ -1,0 +1,2 @@
+import SWIPL = require("../common");
+export = SWIPL;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,14 @@ RUN git submodule update --init --depth 1 -j 100 \
     packages/nlp packages/pcre packages/plunit packages/sgml packages/RDF \
     packages/semweb packages/zlib
 
+# Add the swipl-web-no-data link target: an external (streamable) .wasm
+# with no .data preload and no base64 embedding.  The snippet is
+# appended (rather than applied as a context patch) so it keeps working
+# across SWIPL_COMMIT bumps, and it is guarded to become a no-op if
+# swipl-devel ever ships the target itself.
+COPY swipl-web-no-data.cmake /tmp/swipl-web-no-data.cmake
+RUN cat /tmp/swipl-web-no-data.cmake >> /swipl-devel/cmake/EmscriptenTargets.cmake
+
 # Build SWIPL
 WORKDIR /swipl-devel/build.wasm
 RUN mkdir -p /swipl-devel/build.wasm

--- a/docker/swipl-web-no-data.cmake
+++ b/docker/swipl-web-no-data.cmake
@@ -1,0 +1,27 @@
+
+# Create swipl-web-no-data.js + swipl-web-no-data.wasm
+#
+# Same packaging as swipl-web (external, streamable .wasm and a small
+# MODULARIZE'd JS glue), but without `--preload-file`, so no
+# swipl-web-no-data.data is produced and the glue never fetches one.
+# Like swipl-bundle-no-data, the result cannot load the standard
+# Prolog library and must be booted from a saved state
+# (e.g. `-x image.pvm`).
+#
+# This file is appended to cmake/EmscriptenTargets.cmake of swipl-devel
+# by the npm-swipl-wasm Docker build.  It reuses WASM_DIST_LINK_FLAGS,
+# SWIPL_SRC, PREJS and POSTJS defined earlier in that file.  The block
+# is guarded so it becomes a no-op if a future swipl-devel ships the
+# target itself.
+if(NOT TARGET swipl-web-no-data)
+  set(WASM_NO_DATA_WEB_LINK_FLAGS
+      -Wno-unused-main)
+  join_list(WASM_NO_DATA_WEB_LINK_FLAGS_STRING " "
+	    ${WASM_NO_DATA_WEB_LINK_FLAGS} ${WASM_DIST_LINK_FLAGS})
+  add_executable(swipl-web-no-data ${SWIPL_SRC})
+  set_target_properties(swipl-web-no-data PROPERTIES
+			LINK_FLAGS "${WASM_NO_DATA_WEB_LINK_FLAGS_STRING}")
+  target_link_libraries(swipl-web-no-data libswipl)
+  set_property(TARGET swipl-web-no-data PROPERTY LINK_DEPENDS
+	       ${POSTJS} ${PREJS})
+endif()

--- a/examples/browser-no-data.html
+++ b/examples/browser-no-data.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF8">
+    <title>SWI-Prolog WebAssembly no-data browser test</title>
+  </head>
+  <body>
+    <div id="solution"></div>
+    <script src="/dist/swipl/swipl-web-no-data.js"></script>
+    <script>
+      (async () => {
+        // The no-data build ships no Prolog library, so it boots from a
+        // saved state.  Only swipl-web-no-data.wasm is fetched by the
+        // runtime itself (streamed via WebAssembly.instantiateStreaming).
+        const response = await fetch('/examples/no-data-image.pvm');
+        const image = new Uint8Array(await response.arrayBuffer());
+        const swipl = await SWIPL({
+          arguments: ['-q', '-x', 'image.pvm'],
+          preRun: [(module) => module.FS.writeFile('image.pvm', image)],
+          locateFile: (path) => {
+            return `/dist/swipl/${path}`;
+          }
+        });
+        const solutionElement = document.getElementById('solution');
+        const firstSolution = swipl.prolog.query('hello(X).').once().X;
+        solutionElement.textContent = firstSolution;
+      })();
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "build:wasm-docker:extract:data": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web.data dist/swipl/swipl-web.data",
     "build:wasm-docker:extract:wasm": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web.wasm dist/swipl/swipl-web.wasm",
     "build:wasm-docker:extract:web": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web.js dist/swipl/swipl-web.js",
+    "build:wasm-docker:extract:webNoData": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web-no-data.js dist/swipl/swipl-web-no-data.js",
+    "build:wasm-docker:extract:webNoDataWasm": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web-no-data.wasm dist/swipl/swipl-web-no-data.wasm",
     "build:wasm-docker:extract:bundle": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-bundle.js dist/swipl/swipl-bundle.js",
     "build:wasm-docker:extract:bundleNoData": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-bundle-no-data.js dist/swipl/swipl-bundle-no-data.js",
     "build:wasm-docker:extract:node": "docker cp swipl-wasm:/swipl-devel/build.wasm/src/swipl-web.js dist/swipl/swipl.js",

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -1,3 +1,5 @@
+const assert = require("assert");
+const fs = require("fs");
 const http = require("http");
 const path = require("path");
 const static = require("node-static");
@@ -45,6 +47,52 @@ describe("SWI-Prolog WebAssembly on Browser", () => {
       }
     } finally {
       server.close();
+    }
+  });
+
+  it("should run the no-data web build from a saved state fetching only the wasm", async () => {
+    // The no-data builds do not ship the Prolog library, so the page
+    // boots from a saved state that we generate up front.
+    const imagePath = path.join(__dirname, "..", "examples", "no-data-image.pvm");
+    const SWIPL_BUNDLE = require("../dist/swipl/swipl-bundle");
+    const bundle = await SWIPL_BUNDLE({
+      arguments: ["-q", "-f", "prolog.pl"],
+      preRun: [(module) => module.FS.writeFile("prolog.pl", "hello(world).\n")],
+    });
+    bundle.prolog.query('qsave_program("image.pvm")').once();
+    fs.writeFileSync(imagePath, bundle.FS.readFile("/image.pvm"));
+
+    const server = await createServer();
+    try {
+      const browser = await puppeteer.launch({ headless: "new" });
+      try {
+        const page = await browser.newPage();
+        page.setDefaultTimeout(1_5000);
+        page.setDefaultNavigationTimeout(1_5000);
+        const requestedPaths = [];
+        page.on("request", (request) => {
+          requestedPaths.push(new URL(request.url()).pathname);
+        });
+        await page.goto("http://localhost:8080/examples/browser-no-data.html");
+        await page.waitForSelector("#solution");
+        await page.waitForFunction(() => {
+          const solutionElement = document.querySelector("#solution");
+          return solutionElement.textContent === "world";
+        });
+        assert.ok(
+          requestedPaths.some((p) => p.endsWith("/swipl-web-no-data.wasm")),
+          "the external wasm must be fetched"
+        );
+        assert.ok(
+          requestedPaths.every((p) => !p.endsWith(".data")),
+          "no .data file may be fetched"
+        );
+      } finally {
+        await browser.close();
+      }
+    } finally {
+      server.close();
+      fs.rmSync(imagePath, { force: true });
     }
   });
 });

--- a/tests/node.js
+++ b/tests/node.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const fs = require("fs");
 const path = require("path");
 
 describe("SWI-Prolog WebAssembly on Node.js", () => {
@@ -188,4 +189,43 @@ describe("SWI-Prolog WebAssembly on Node.js", () => {
       assert.deepEqual(errorMessages, []);
     });
   }
+});
+
+describe("SWI-Prolog WebAssembly no-data web build", () => {
+  const SWIPL_WEB_NO_DATA = require("../dist/swipl/swipl-web-no-data");
+  const SWIPL_BUNDLE = require("../dist/swipl/swipl-bundle");
+  const swiplDir = path.join(__dirname, "..", "dist", "swipl");
+
+  // Build a saved state to boot from; the no-data builds do not ship
+  // the Prolog library, so they can only start from an image.
+  async function generateImage() {
+    const bundle = await SWIPL_BUNDLE({
+      arguments: ["-q", "-f", "prolog.pl"],
+      preRun: [(module) => module.FS.writeFile("prolog.pl", "hello(world).\n")],
+    });
+    bundle.prolog.query('qsave_program("image.pvm")').once();
+    return bundle.FS.readFile("/image.pvm");
+  }
+
+  it("should ship an external wasm and no data preload", () => {
+    const glue = fs.readFileSync(path.join(swiplDir, "swipl-web-no-data.js"), "utf8");
+    assert.ok(glue.includes("swipl-web-no-data.wasm"), "glue must reference the external wasm");
+    assert.ok(!glue.includes("swipl-web-no-data.data"), "glue must not reference a data preload");
+    assert.ok(!fs.existsSync(path.join(swiplDir, "swipl-web-no-data.data")), "no data file may be produced");
+  });
+
+  it("should boot from a saved state fetching only the wasm", async () => {
+    const image = await generateImage();
+    const located = [];
+    const swipl = await SWIPL_WEB_NO_DATA({
+      arguments: ["-q", "-x", "image.pvm"],
+      preRun: [(module) => module.FS.writeFile("image.pvm", image)],
+      locateFile: (name) => {
+        located.push(name);
+        return path.join(swiplDir, name);
+      },
+    });
+    assert.strictEqual(swipl.prolog.query("hello(X).").once().X, "world");
+    assert.ok(located.every((name) => !name.endsWith(".data")), "no .data file may be requested");
+  });
 });


### PR DESCRIPTION
## What

Adds the missing cell of the build matrix: **`swipl-web-no-data`** — an external, streamable `.wasm` (like `swipl-web`) with **no `.data` file and no base64 embedding** (like `swipl-bundle-no-data`).

| variant | wasm delivery | `.data` (1.6 MB) |
|---|---|---|
| `swipl-web` | external `.wasm` (streamable) | always fetched |
| `swipl-bundle` | base64 inside the JS | embedded |
| `swipl-bundle-no-data` | base64 inside the JS | omitted |
| **`swipl-web-no-data` (this PR)** | **external `.wasm` (streamable)** | **omitted** |

Like `swipl-bundle-no-data`, the new variant ships no Prolog library, so it must boot from a saved state (`-x image.pvm`, see "Generating an Image" in the README). For embedders that already boot from an image (e.g. eye-js, see eyereasoner/eye-js#1957), this is the smallest and best-cacheable way to deliver SWI-Prolog: the browser can compile the wasm with `WebAssembly.instantiateStreaming` while it downloads, and cache it independently of application JS.

## How

The three existing variants are link targets defined in swipl-devel's `cmake/EmscriptenTargets.cmake`; this repo's Docker build just compiles them and `docker cp`s the artifacts out. The new target is the cross product of flags that already exist there: `WASM_DIST_LINK_FLAGS` **without** `--preload-file` (drops the `.data` and the file-packager glue) and **without** `-s SINGLE_FILE` (keeps the wasm external).

- `docker/swipl-web-no-data.cmake` (new): the link target, reusing `WASM_DIST_LINK_FLAGS`/`SWIPL_SRC`/`PREJS`/`POSTJS` from `EmscriptenTargets.cmake`. Guarded with `if(NOT TARGET ...)` so it becomes a no-op if swipl-devel ships the target upstream one day (happy to file it there as a follow-up).
- `docker/Dockerfile`: appends the snippet to swipl-devel's `EmscriptenTargets.cmake` after checkout. Appending (rather than a context patch) keeps working across `SWIPL_COMMIT` bumps from the update workflow.
- `package.json`: two new `build:wasm-docker:extract:*` entries copy `swipl-web-no-data.js` / `swipl-web-no-data.wasm` out of the container (picked up automatically by `run-s build:wasm-docker:extract:*`).
- `dist/swipl/swipl-web-no-data.d.ts`, `dist/loadImageWeb.ts`: typings + a `loadImageDefault`-style helper bound to the new variant.
- `tests/node.js`: boots the new variant from a `qsave_program` image and asserts the answer is produced, that only the `.wasm` is located (never a `.data`), and that the glue contains no data-preload reference.
- `tests/browser.js` + `examples/browser-no-data.html`: same end-to-end in Puppeteer, asserting via the network log that `swipl-web-no-data.wasm` is fetched and **no** `.data` request is ever made.
- `.github/workflows/nodejs.yml`: the build cache key now also hashes `docker/*`. This is needed for this PR (otherwise CI restores the cached `dist/swipl` and never builds the new artifacts) and fixes a latent issue where Dockerfile changes did not invalidate the artifact cache.
- README: documents the variant.

## Wire sizes

Measured on the **published swipl-wasm 8.0.3 artifacts** (brotli `-q 11`, via Node's `zlib`):

| artifact | raw | brotli |
|---|---|---|
| `swipl-web.wasm` | 2.09 MB | 0.60 MB |
| `swipl-web.js` | 188 KB | 42 KB |
| `swipl-web.data` | 1.57 MB | 0.96 MB |
| `swipl-bundle-no-data.js` | 2.47 MB | 0.65 MB |
| `swipl-bundle.js` | 5.92 MB | 1.40 MB |

Expected for `swipl-web-no-data` (**estimate** — the artifacts are produced by CI, see below): the `.wasm` links from the same objects with the same codegen flags, so ~2.09 MB raw / ~0.60 MB brotli; the glue is the `swipl-web` glue minus the file-packager block, ~146 KB raw / ~33 KB brotli (measured on an emulation, see below). Total **~0.64 MB brotli** + the application's own `.pvm` image, versus ~1.60 MB for `swipl-web` today (which unconditionally drags the `.data`) and 1.40 MB for `swipl-bundle`.

Against `swipl-bundle-no-data` (~0.65 MB) the byte win is small — the real difference is delivery quality: streaming wasm compile instead of parsing 2.5 MB of JavaScript and base64-decoding the wasm out of it, plus the `.wasm` being separately cacheable.

One cost to be aware of: the npm tarball grows by roughly the new `swipl-web-no-data.js` + `swipl-web-no-data.wasm` (~2.3 MB raw). The new `.wasm` should be functionally identical to `swipl-web.wasm` (only the packaging flags differ), so if tarball size matters we could later dedupe by shipping only the glue and defaulting `locateFile` to `swipl-web.wasm` — kept out of this PR to avoid coupling the variants.

## Validation status

**Build config authored but NOT validated in the author's environment — needs CI to produce/verify the artifacts.** I could not run the emsdk Docker build on the machine this was authored on (2-core box, insufficient disk headroom). What was validated locally:

- **Runtime semantics, by emulation:** taking the published 8.0.3 `swipl-web.js` glue and removing the file-packager IIFE (precisely the code that `--preload-file` adds) yields a glue that boots `-x image.pvm` from a `qsave_program/1` image with **only** `swipl-web.wasm` ever located — no `.data` request — and answers queries correctly (`current_prolog_flag(version, 100110)`). This is the exact shape of glue Emscripten emits without `--preload-file`.
- The new node/browser tests were run locally against those emulated artifacts (glue with the wasm reference renamed + the published wasm), so the test code itself is exercised; CI re-runs them against the real built artifacts.
- `npm run tsc` and `npm run lint` pass.

Because the cache key changes, this PR's CI run performs a full Docker build and then runs the new tests against the freshly built artifacts — that run is the authoritative validation. Note the full-build path failed transiently on 2 July (`zlib.net` download flaked on the `fix/update-emsdk-v6.0.2` branch); the URL responds again, so a re-run should suffice if it recurs. If it keeps flaking, switching the Dockerfile to `https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz` would be a robust follow-up.

**Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
